### PR TITLE
Background processing

### DIFF
--- a/app/jobs/solidus_importer/import_job.rb
+++ b/app/jobs/solidus_importer/import_job.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module SolidusImporter
+  class ImportJob < ActiveJob::Base
+    queue_as :default
+
+    retry_on ActiveRecord::Deadlocked
+
+    def perform(import_id)
+      raise ArgumentError, 'Missing import id' unless import_id
+
+      import = ::SolidusImporter::Import.find(import_id)
+      ::SolidusImporter::ProcessImport.new(import).process
+    end
+  end
+end

--- a/app/models/solidus_importer/import.rb
+++ b/app/models/solidus_importer/import.rb
@@ -23,14 +23,18 @@ module SolidusImporter
     validates :import_type, presence: true, allow_blank: false
     validates :state, presence: true, allow_blank: false
 
-    def import_file=(path)
-      raise SolidusImporter::Exception, 'Existing file required' if !path || !File.exist?(path)
-
-      self.file = File.open(path, 'r')
+    def created_or_failed?
+      %w[created failed].include? state
     end
 
     def finished?
       rows.failed_or_completed.size == rows.size
+    end
+
+    def import_file=(path)
+      raise SolidusImporter::Exception, 'Existing file required' if !path || !File.exist?(path)
+
+      self.file = File.open(path, 'r')
     end
   end
 end

--- a/app/models/solidus_importer/row.rb
+++ b/app/models/solidus_importer/row.rb
@@ -17,6 +17,7 @@ module SolidusImporter
       completed: 'completed'
     }
 
+    scope :created_or_failed, -> { where(state: %i[created failed]) }
     scope :failed_or_completed, -> { where(state: %i[failed completed]) }
 
     validates :data, presence: true, allow_blank: false

--- a/spec/jobs/solidus_importer/import_job_spec.rb
+++ b/spec/jobs/solidus_importer/import_job_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe SolidusImporter::ImportJob do
+  describe '#perform' do
+    subject(:described_method) { described_class.perform_now(import_id) }
+
+    let(:import_id) {}
+
+    it { expect { described_method }.to raise_error(ArgumentError) }
+
+    context 'with a missing import' do
+      let(:import_id) { 123 }
+
+      it { expect { described_method }.to raise_error(ActiveRecord::RecordNotFound) }
+    end
+
+    context 'with a source file' do
+      let(:import) { build_stubbed(:solidus_importer_import_customers) }
+      let(:import_id) { import.id }
+      let(:process_import) { instance_double(SolidusImporter::ProcessImport, process: nil) }
+
+      before do
+        allow(SolidusImporter::Import).to receive_messages(find: import)
+        allow(SolidusImporter::ProcessImport).to receive(:new).with(import).and_return(process_import)
+        described_method
+      end
+
+      it { expect(SolidusImporter::ProcessImport).to have_received(:new).with(import) }
+      it { expect(process_import).to have_received(:process).with(no_args) }
+    end
+  end
+end


### PR DESCRIPTION
A basic approach for background processing: a unique job that handles a single import with all the relative rows and attachments.

The state of the Import and Row entities permits to launch the task on the same import multiple times to:
- retry failed imports;
- continue interrupted imports (but requires that the import entity state is reset to `failed`).