### PR TITLE
Implement product options processors

### DIFF
--- a/lib/solidus_importer/configuration.rb
+++ b/lib/solidus_importer/configuration.rb
@@ -22,6 +22,7 @@ module SolidusImporter
         processors: [
           SolidusImporter::Processors::Product,
           SolidusImporter::Processors::Variant,
+          SolidusImporter::Processors::OptionTypes,
           SolidusImporter::Processors::ProductImages,
           SolidusImporter::Processors::VariantImages,
           SolidusImporter::Processors::Log

--- a/lib/solidus_importer/configuration.rb
+++ b/lib/solidus_importer/configuration.rb
@@ -23,6 +23,7 @@ module SolidusImporter
           SolidusImporter::Processors::Product,
           SolidusImporter::Processors::Variant,
           SolidusImporter::Processors::OptionTypes,
+          SolidusImporter::Processors::OptionValues,
           SolidusImporter::Processors::ProductImages,
           SolidusImporter::Processors::VariantImages,
           SolidusImporter::Processors::Log

--- a/lib/solidus_importer/processors/option_types.rb
+++ b/lib/solidus_importer/processors/option_types.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module SolidusImporter
+  module Processors
+    class OptionTypes < Base
+      def call(context)
+        @data = context.fetch(:data)
+        return unless option_types?
+
+        product = context.fetch(:product)
+        context.merge!(option_types: process_option_types(product))
+      end
+
+      private
+
+      def process_option_types(product)
+        option_type_names.each_with_index.map do |name, i|
+          option_type = product.option_types.find_or_initialize_by(
+            name: name
+          )
+          option_type.presentation = name
+          option_type.name = name.downcase
+          option_type.position = i + 1
+          option_type.save
+        end
+      end
+
+      def option_type_names
+        @option_type_names ||= @data.values_at(
+          'Option1 Name',
+          'Option2 Name',
+          'Option3 Name'
+        ).compact
+      end
+
+      def option_types?
+        # NOTE: according to https://help.shopify.com/en/manual/products/import-export
+        # when `Option Name1` is equal to 'Title`, means that product has no variants.
+        (@data['Option1 Name'] != 'Title') && option_type_names.any?
+      end
+    end
+  end
+end

--- a/lib/solidus_importer/processors/option_values.rb
+++ b/lib/solidus_importer/processors/option_values.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module SolidusImporter
+  module Processors
+    class OptionValues < Base
+      attr_accessor :option_types, :variant
+
+      def call(context)
+        @data = context.fetch(:data)
+        return unless option_values?
+
+        self.variant = context.fetch(:variant)
+        process_option_values
+      end
+
+      private
+
+      def process_option_values
+        option_value_names.each_with_index do |name, i|
+          option_value = Spree::OptionValue.find_or_initialize_by(
+            option_type: option_type(i),
+            name: name
+          )
+          option_value.presentation = name
+          variant.option_values << option_value
+        end
+      end
+
+      def option_type(index)
+        variant.product.option_types.find { |ot| ot.position == index + 1 }
+      end
+
+      def option_value_names
+        @option_value_names ||= @data.values_at(
+          'Option1 Value',
+          'Option2 Value',
+          'Option3 Value'
+        ).compact
+      end
+
+      def option_values?
+        # NOTE: according to https://help.shopify.com/en/manual/products/import-export
+        # when `Option Value1` is equal to 'Default Title`, means that product has no
+        # variants.
+        (@data['Option1 Value'] != 'Default Title') && option_value_names.any?
+      end
+    end
+  end
+end

--- a/spec/features/solidus_importer/import_spec.rb
+++ b/spec/features/solidus_importer/import_spec.rb
@@ -45,6 +45,8 @@ RSpec.describe 'Import from CSV files' do # rubocop:disable RSpec/DescribeClass
       expect(product.variants.count).to eq(3)
       expect(product.slug).to eq(product_slug)
       expect(import.state).to eq('completed')
+      expect(product.images).not_to be_empty
+      expect(product.option_types.count).to eq 2
       expect(Spree::Product.last.images).not_to be_empty
       expect(Spree::Variant.last.images).not_to be_empty
       expect(Spree::LogEntry).to have_received(:create!).exactly(csv_file_rows).times

--- a/spec/features/solidus_importer/import_spec.rb
+++ b/spec/features/solidus_importer/import_spec.rb
@@ -47,6 +47,8 @@ RSpec.describe 'Import from CSV files' do # rubocop:disable RSpec/DescribeClass
       expect(import.state).to eq('completed')
       expect(product.images).not_to be_empty
       expect(product.option_types.count).to eq 2
+      expect(product.variants.sample.option_values.count).to eq 2
+      expect(product.variants.sample.images).not_to be_empty
       expect(Spree::Product.last.images).not_to be_empty
       expect(Spree::Variant.last.images).not_to be_empty
       expect(Spree::LogEntry).to have_received(:create!).exactly(csv_file_rows).times

--- a/spec/lib/solidus_importer/processors/option_types_spec.rb
+++ b/spec/lib/solidus_importer/processors/option_types_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe SolidusImporter::Processors::OptionTypes do
+  describe '#call' do
+    subject(:described_method) { described_class.call(context) }
+
+    let(:context) { { data: data, product: product } }
+    let(:product) { create :base_product }
+    let(:color) { create :option_type, presentation: 'The color', name: 'Color' }
+    let(:size) { create :option_type, presentation: 'The size', name: 'Size' }
+    let(:data) do
+      {
+        'Option1 Name' => 'Size',
+        'Option2 Name' => 'Color'
+      }
+    end
+
+    context 'when "Option(1,2,3) Name" are present' do
+      context 'when product already has option types' do
+        before { product.option_types << color << size }
+
+        it 'do not create other option types' do
+          expect { described_method }.not_to change(product.option_types, :count)
+        end
+      end
+
+      it 'create option types for product in row' do
+        expect { described_method }.to change(product.option_types, :count).from(0).to(2)
+        expect(product.option_types.first.presentation).to eq 'Size'
+        expect(product.option_types.first.name).to eq 'size'
+        expect(product.option_types.last.presentation).to eq 'Color'
+        expect(product.option_types.last.name).to eq 'color'
+      end
+    end
+  end
+end

--- a/spec/lib/solidus_importer/processors/option_values_spec.rb
+++ b/spec/lib/solidus_importer/processors/option_values_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe SolidusImporter::Processors::OptionValues do
+  describe '#call' do
+    subject(:described_method) { described_class.call(context) }
+
+    let(:context) { { data: data, variant: variant } }
+    let(:variant) { create :base_variant }
+    let(:product) { variant.product }
+    let(:color) { create :option_type, presentation: 'Color' }
+    let(:size) { create :option_type, presentation: 'Size' }
+    let(:data) do
+      {
+        'Option1 Name' => 'Size',
+        'Option1 Value' => 'L',
+        'Option2 Name' => 'Color',
+        'Option2 Value' => 'Black'
+      }
+    end
+
+    before { product.option_types << size << color }
+
+    context 'when "Option(1,2,3) Value" are present' do
+      it 'create option values for variant in row' do
+        expect { described_method }.to change(variant.option_values, :count).from(0).to(2)
+        expect(variant.option_values.first.presentation).to eq 'L'
+        expect(variant.option_values.first.name).to eq 'L'
+        expect(variant.option_values.last.presentation).to eq 'Black'
+        expect(variant.option_values.last.name).to eq 'Black'
+      end
+
+      it 'creates "Black" option value for related "Color" option type' do
+        described_method
+        black = variant.option_values.find_by(presentation: 'Black')
+        l = variant.option_values.find_by(presentation: 'L')
+        expect(black.option_type).to eq color
+        expect(l.option_type).to eq size
+      end
+    end
+  end
+end


### PR DESCRIPTION
Ref. #15 

Shopify allows a maximum of three key, value options to define product
attributes (I don't know if premium shops permit more options)

We map these keys into into `Spree::OptionType/OptionValue` 