### PR TITLE
Fix and improve customer processor

### DIFF
--- a/lib/solidus_importer/configuration.rb
+++ b/lib/solidus_importer/configuration.rb
@@ -6,6 +6,7 @@ module SolidusImporter
       customers: {
         importer: SolidusImporter::BaseImporter,
         processors: [
+          SolidusImporter::Processors::Address,
           SolidusImporter::Processors::Customer,
           SolidusImporter::Processors::Log
         ]

--- a/lib/solidus_importer/processors/address.rb
+++ b/lib/solidus_importer/processors/address.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module SolidusImporter
+  module Processors
+    class Address < Base
+      def call(context)
+        @data = context.fetch(:data)
+
+        return unless address?
+
+        context.merge!(address: process_address)
+      end
+
+      private
+
+      def process_address
+        prepare_address.tap(&:save)
+      end
+
+      def prepare_address
+        Spree::Address.new(
+          firstname: @data['First Name'],
+          lastname: @data['Last Name'],
+          address1: @data['Address1'],
+          address2: @data['Address2'],
+          city: @data['City'],
+          zipcode: @data['Zip'],
+          phone: @data['Phone'],
+          country: extract_country(@data['Country Code']),
+          state: extract_state(@data['Province Code'])
+        )
+      end
+
+      def extract_country(iso)
+        Spree::Country.find_by(iso: iso)
+      end
+
+      def extract_state(iso)
+        Spree::State.find_by(abbr: iso) || Spree::State.find_by(name: iso)
+      end
+
+      def address?
+        @data['Address1'].present?
+      end
+    end
+  end
+end

--- a/lib/solidus_importer/processors/customer.rb
+++ b/lib/solidus_importer/processors/customer.rb
@@ -3,9 +3,14 @@
 module SolidusImporter
   module Processors
     class Customer < Base
+      attr_accessor :address
+
       def call(context)
         @data = context.fetch(:data)
         check_data
+
+        self.address = context[:address]
+
         context.merge!(user: process_user)
       end
 
@@ -24,6 +29,7 @@ module SolidusImporter
       def prepare_user
         Spree::User.find_or_initialize_by(email: @data['Email']) do |u|
           u.password = options[:password_method].call(u)
+          u.bill_address = address if address.present?
         end
       end
 

--- a/lib/solidus_importer/processors/customer.rb
+++ b/lib/solidus_importer/processors/customer.rb
@@ -18,11 +18,11 @@ module SolidusImporter
       private
 
       def check_data
-        raise SolidusImporter::Exception, 'Missing required key: "Email Address"' if @data['Email Address'].blank?
+        raise SolidusImporter::Exception, 'Missing required key: "Email"' if @data['Email'].blank?
       end
 
       def prepare_user
-        Spree::User.find_or_initialize_by(email: @data['Email Address']) do |u|
+        Spree::User.find_or_initialize_by(email: @data['Email']) do |u|
           u.password = options[:password_method].call(u)
         end
       end

--- a/spec/factories/solidus_importer_rows.rb
+++ b/spec/factories/solidus_importer_rows.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :solidus_importer_row_customer, class: 'SolidusImporter::Row' do
-    data { { 'Email Address' => 'an_email@example.com' } }
+    data { { 'Email' => 'an_email@example.com' } }
 
     trait :with_import do
       after(:build) do |row|

--- a/spec/factories/solidus_importer_rows.rb
+++ b/spec/factories/solidus_importer_rows.rb
@@ -24,7 +24,9 @@ FactoryBot.define do
   end
 
   factory :solidus_importer_row_customer, class: 'SolidusImporter::Row' do
-    data { { 'Email' => 'an_email@example.com' } }
+    data do
+      { 'Email' => 'an_email@example.com' }.merge(build(:solidus_importer_row_address).data)
+    end
 
     trait :with_import do
       after(:build) do |row|

--- a/spec/factories/solidus_importer_rows.rb
+++ b/spec/factories/solidus_importer_rows.rb
@@ -1,6 +1,28 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
+  factory :solidus_importer_row_address, class: 'SolidusImporter::Row' do
+    data do
+      {
+        'First Name' => 'John',
+        'Last Name' => 'Doe',
+        'Address1' => 'My Cool Address, n.1',
+        'Address2' => '',
+        'City' => 'My beautiful City',
+        'Zip' => '12345',
+        'Phone' => '(555)-123123123',
+        'Country Code' => 'US',
+        'Province Code' => 'WA'
+      }
+    end
+
+    trait :with_import do
+      after(:build) do |row|
+        row.import = build_stubbed(:solidus_importer_import_orders)
+      end
+    end
+  end
+
   factory :solidus_importer_row_customer, class: 'SolidusImporter::Row' do
     data { { 'Email' => 'an_email@example.com' } }
 

--- a/spec/features/solidus_importer/processors_spec.rb
+++ b/spec/features/solidus_importer/processors_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'Set up a some processors' do # rubocop:disable RSpec/DescribeCla
 
   let(:processor_create_user) do
     ->(context) {
-      user = Spree::User.new(email: context[:data]['Email Address'])
+      user = Spree::User.new(email: context[:data]['Email'])
       user.password = 'a very secure password'
       context.merge!(success: user.save, user: user)
     }

--- a/spec/fixtures/solidus_importer/customer1.csv
+++ b/spec/fixtures/solidus_importer/customer1.csv
@@ -1,3 +1,0 @@
-First Name,Last Name,Email Address
-Jane,Doe,jane.doe01520022060@example.com
-Jane,Doe,jane.doe11520022060@example.com

--- a/spec/fixtures/solidus_importer/customer2.csv
+++ b/spec/fixtures/solidus_importer/customer2.csv
@@ -1,2 +1,0 @@
-First Name,Last Name,Email Address
-Jane,Doe,jane.doe2@example.com

--- a/spec/fixtures/solidus_importer/customers.csv
+++ b/spec/fixtures/solidus_importer/customers.csv
@@ -1,3 +1,3 @@
-First Name,Last Name,Email Address
+First Name,Last Name,Email
 Jane,Doe,jane.doe01520022060@example.com
 Jane,Doe,jane.doe11520022060@example.com

--- a/spec/lib/solidus_importer/processors/address_spec.rb
+++ b/spec/lib/solidus_importer/processors/address_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe SolidusImporter::Processors::Address do
+  describe '#call' do
+    subject(:described_method) { described_class.call(context) }
+
+    let(:context) { { data: data } }
+    let(:data) { create(:solidus_importer_row_address, :with_import).data }
+    let!(:country) { create :country, iso: 'US' }
+    let!(:state) { create :state, abbr: 'WA' }
+
+    it 'create an address' do
+      expect { described_method }.to change(Spree::Address, :count).from(0).to(1)
+    end
+  end
+end

--- a/spec/lib/solidus_importer/processors/customer_spec.rb
+++ b/spec/lib/solidus_importer/processors/customer_spec.rb
@@ -14,13 +14,13 @@ RSpec.describe SolidusImporter::Processors::Customer do
       end
 
       it 'raises an exception' do
-        expect { described_method }.to raise_error(SolidusImporter::Exception, 'Missing required key: "Email Address"')
+        expect { described_method }.to raise_error(SolidusImporter::Exception, 'Missing required key: "Email"')
       end
     end
 
     context 'with invalid fields in row data' do
       let(:context) do
-        { data: { 'Email Address' => '-' } }
+        { data: { 'Email' => '-' } }
       end
 
       it 'raises an exception' do


### PR DESCRIPTION
According to [Shopify imports manual](https://help.shopify.com/en/manual/customers/import-export-customers) the email field is mapped onto `Email`, not `Email Address`.

This also improves customers import by adding a bill address where present.