### PR TITLE
Add Taxon processors

### DIFF
--- a/lib/solidus_importer/processors/taxon.rb
+++ b/lib/solidus_importer/processors/taxon.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module SolidusImporter
+  module Processors
+    class Taxon < Base
+      attr_accessor :product, :taxonomy
+
+      def call(context)
+        @data = context.fetch(:data)
+
+        self.product = context.fetch(:product)
+
+        process_taxons_type
+        process_taxons_tags
+      end
+
+      private
+
+      def options
+        @options ||= {
+          type_taxonomy: Spree::Taxonomy.find_or_create_by(name: 'Type'),
+          tags_taxonomy: Spree::Taxonomy.find_or_create_by(name: 'Tags')
+        }
+      end
+
+      def process_taxons_type
+        product.taxons << prepare_taxon(type, options[:type_taxonomy])
+      end
+
+      def process_taxons_tags
+        tags.map do |tag|
+          product.taxons << prepare_taxon(tag, options[:tags_taxonomy])
+        end
+      end
+
+      def prepare_taxon(name, taxonomy)
+        Spree::Taxon.find_or_initialize_by(
+          name: name,
+          taxonomy_id: taxonomy.id
+        )
+      end
+
+      def tags
+        @data['Tags'].split(',').map(&:strip)
+      end
+
+      def type
+        @data['Type']
+      end
+    end
+  end
+end

--- a/spec/factories/solidus_importer_rows.rb
+++ b/spec/factories/solidus_importer_rows.rb
@@ -53,6 +53,14 @@ FactoryBot.define do
         row.import = build_stubbed(:solidus_importer_import_products)
       end
     end
+
+    trait :with_tags do
+      after(:build) { |row| row.data.merge!('Tags' => 'Tag1,Tag2, Tag3') }
+    end
+
+    trait :with_type do
+      after(:build) { |row| row.data.merge!('Type' => 'Type1') }
+    end
   end
 
   factory :solidus_importer_row_variant, class: 'SolidusImporter::Row' do

--- a/spec/lib/solidus_importer/processors/taxon_spec.rb
+++ b/spec/lib/solidus_importer/processors/taxon_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe SolidusImporter::Processors::Taxon do
+  describe '#call' do
+    subject(:described_method) { described_class.call(context) }
+
+    let!(:shipping_category) { create :shipping_category }
+    let(:context) { { data: data, product: product } }
+    let(:product) { create :product }
+    let(:data) { build(:solidus_importer_row_product, :with_import, :with_type, :with_tags).data }
+    let(:tags_taxonomy) { Spree::Taxonomy.find_by(name: 'Tags') }
+    let(:type_taxonomy) { Spree::Taxonomy.find_by(name: 'Type') }
+
+    it 'create a taxon for each tag, related to the given taxonomy' do
+      expect { described_method }.to change(product.taxons, :count).by(4)
+
+      %w[Type1 Tag1 Tag2 Tag3].each do |taxon_name|
+        expect(product.taxons.map(&:name)).to include(taxon_name)
+      end
+
+      expect(Spree::Taxon.find_by(name: 'Tag1').taxonomy).to eq tags_taxonomy
+      expect(Spree::Taxon.find_by(name: 'Type1').taxonomy).to eq type_taxonomy
+    end
+
+    it 'creates "Type" and "Tags" taxonomies' do
+      described_method
+      expect(type_taxonomy).to be_present
+      expect(tags_taxonomy).to be_present
+    end
+  end
+end


### PR DESCRIPTION
Ref. #14 

We map the 'Tags' field (which is a comma-separated list of tag) onto a `Spree::Taxon` belonging to a `Tags` taxonomy.
We map the `Type` field onto a `Spree::Taxon` beloinging to a `Type` taxonomy.

For more info about export files format see [Shopify documentation](https://help.shopify.com/en/manual/products/import-export/using-csv#csv-files).